### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 WOFpy.egg-info/
 dist/
 .idea/
+.cache


### PR DESCRIPTION
Simple PR and easy merge. Just adds the `.cache` directory to the ignore list for when we run `py.test` locally.