### PR TITLE
Fix configparser imports

### DIFF
--- a/test/test_wofpy_soap.py
+++ b/test/test_wofpy_soap.py
@@ -7,7 +7,10 @@ import unittest
 from examples.flask.swis.swis_dao import SwisDao
 import wof
 import wof.flask
-import ConfigParser
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 from threading import Thread
 import requests
 
@@ -18,7 +21,7 @@ openPort=8080
 
 
 def setupServer():
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.readfp(open(SWIS_CONFIG_FILE))
 
     swis_dao = SwisDao(SWIS_CONFIG_FILE, database_uri="sqlite:///test_swis2.db")

--- a/wof/__init__.py
+++ b/wof/__init__.py
@@ -1,7 +1,6 @@
 # The version as used in the setup.py
 from __future__ import (absolute_import, division, print_function)
 
-
 __version__ = "2.0.11b0"
 
 from core import _SERVICE_PARAMS, site_map

--- a/wof/apps/__init__.py
+++ b/wof/apps/__init__.py
@@ -1,4 +1,3 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 __author__ = 'cyoun'

--- a/wof/apps/spyned_1_0.py
+++ b/wof/apps/spyned_1_0.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 import StringIO
 import logging
 
@@ -10,6 +9,7 @@ from spyne.model.primitive import Unicode, AnyXml
 from spyne.model.fault import Fault
 from spyne.service import ServiceBase
 from spyne.util import memoize
+
 import wof
 
 __author__ = 'cyoun'

--- a/wof/apps/spyned_1_1.py
+++ b/wof/apps/spyned_1_1.py
@@ -1,7 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-
-
 import StringIO
 import logging
 
@@ -11,9 +9,9 @@ from spyne.model.primitive import Unicode, AnyXml, Float, Boolean
 from spyne.service import ServiceBase
 from spyne.model.fault import Fault
 from spyne.util import memoize
-import wof
 from lxml import etree
 
+import wof
 
 __author__ = 'cyoun'
 

--- a/wof/apps/waterml2.py
+++ b/wof/apps/waterml2.py
@@ -11,10 +11,10 @@ from spyne.model.primitive import Unicode, AnyXml, Float, Boolean
 from spyne.service import ServiceBase
 from spyne.model.fault import Fault
 from spyne.util import memoize
-import wof
 from dateutil.parser import parse
-
 from jinja2 import Environment, Template, PackageLoader, FileSystemLoader
+
+import wof
 
 logger = logging.getLogger(__name__)
 

--- a/wof/core.py
+++ b/wof/core.py
@@ -1,7 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
-
-import ConfigParser
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 import cgi
 import datetime
 import logging
@@ -101,7 +103,7 @@ class WOFConfig(object):
         TEMPLATES = '../../wof/apps/templates'
 
         def __init__(self, file_name,templates=None):
-            config = ConfigParser.RawConfigParser()
+            config = configparser.RawConfigParser()
             config.read(file_name)
 
             if config.has_option('WOF_1_1','Network'):

--- a/wof/core_1_0.py
+++ b/wof/core_1_0.py
@@ -1,13 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 import datetime
 from xml.sax.saxutils import escape
 
-import ConfigParser
-import WaterML
-import core
 import logging
+
+import core
+import WaterML
 
 class WOF(object):
 

--- a/wof/core_1_1.py
+++ b/wof/core_1_1.py
@@ -1,14 +1,14 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 import datetime
 from xml.sax.saxutils import escape
 
-import ConfigParser
-import WaterML_1_1 as WaterML
-import core
 import logging
 import dateutil.parser
+
+import WaterML_1_1 as WaterML
+import core
+
 
 class WOF_1_1(object):
 

--- a/wof/flask/__init__.py
+++ b/wof/flask/__init__.py
@@ -1,14 +1,13 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 import urllib
 
 import werkzeug
 from flask import Flask, render_template, current_app, make_response, request
-import wof
 import config
 import datetime
 
+import wof
 from wof.core import wofConfig, getSpyneApplications
 import wof.core_1_1 as wof_1_1
 import wof.core_1_0 as wof_1_0

--- a/wof/flask/config.py
+++ b/wof/flask/config.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-
 class Config(object):
     DEBUG = False
     TESTING = False


### PR DESCRIPTION
In this PR:

- `ConfigParser` when it is imported but unused;
- add a Python 2/3 `configparser` import;
- re-organize the imports at the top to place the internal imports at the bottom and make them easier to recognize.