### PR TITLE
Use configparser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ before_install:
     - conda config --add channels odm2 --force
     - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
     - source activate TEST
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        conda install --yes configparser ;
+      fi
 
 # Test source distribution.
 install:

--- a/test/test_wofpy_soap.py
+++ b/test/test_wofpy_soap.py
@@ -1,9 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+
+import configparser
 import unittest
 
 from examples.flask.swis.swis_dao import SwisDao

--- a/wof/core.py
+++ b/wof/core.py
@@ -1,9 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+import configparser
 import cgi
 import datetime
 import logging

--- a/wof/examples/flask/barebones/LCM_dao.py
+++ b/wof/examples/flask/barebones/LCM_dao.py
@@ -1,10 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 import datetime
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+
+import configparser
 from sqlalchemy import create_engine, distinct, func
 from sqlalchemy.orm import mapper, scoped_session, sessionmaker
 from sqlalchemy.sql import and_
@@ -15,7 +13,7 @@ from wof.dao import BaseDao
 import sqlalch_LCM_models as model
 import wof.models as wof_base
 
-# Instantiate zome useful time zones
+# Instantiate some useful time zones.
 utc = tzutc()
 local_tz = tzoffset("EST", -18000)
 

--- a/wof/examples/flask/cbi/cbi_dao.py
+++ b/wof/examples/flask/cbi/cbi_dao.py
@@ -1,9 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+import configparser
 import time
 from io import StringIO
 

--- a/wof/examples/flask/swis/swis_dao.py
+++ b/wof/examples/flask/swis/swis_dao.py
@@ -2,17 +2,15 @@ from __future__ import (absolute_import, division, print_function)
 
 
 import datetime
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+
+import configparser
 from sqlalchemy import create_engine, distinct, func
 from sqlalchemy.orm import mapper, scoped_session, sessionmaker
 from sqlalchemy.sql import and_
 from dateutil.parser import parse
 from dateutil.tz import tzutc
 
-# Instantiate zome useful time zones
+# Instantiate some useful time zones.
 utc = tzutc()
 
 import sqlalch_swis_models as model


### PR DESCRIPTION
OK. Now it is really the last one of the day :smile: 

@lsetiawan, after reading a little I realized that installing `configparser` on Python 2 is the best way to go. the `try`/`except` clause is awkward and prevent people with `configparser` on Python 2 to use it.