### PR TITLE
Fix XML's causing tests to fail on test_wof

### DIFF
--- a/test/test_xml/get_all_variables.xml
+++ b/test/test_xml/get_all_variables.xml
@@ -45,7 +45,7 @@
             <dataType>Continuous</dataType>
             <generalCategory>Water Quality</generalCategory>
             <sampleMedium>Surface Water</sampleMedium>
-            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celcius</units>
+            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celsius</units>
             <NoDataValue>-9999</NoDataValue>
             <timeSupport isRegular="true">
                 <unit UnitID="100">

--- a/test/test_xml/get_one_variable.xml
+++ b/test/test_xml/get_one_variable.xml
@@ -7,7 +7,7 @@
             <dataType>Continuous</dataType>
             <generalCategory>Water Quality</generalCategory>
             <sampleMedium>Surface Water</sampleMedium>
-            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celcius</units>
+            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celsius</units>
             <NoDataValue>-9999</NoDataValue>
             <timeSupport isRegular="true">
                 <unit UnitID="100">

--- a/test/test_xml/get_siteinfo_novar.xml
+++ b/test/test_xml/get_siteinfo_novar.xml
@@ -82,7 +82,7 @@
                     <dataType>Continuous</dataType>
                     <generalCategory>Water Quality</generalCategory>
                     <sampleMedium>Surface Water</sampleMedium>
-                    <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celcius</units>
+                    <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celsius</units>
                     <NoDataValue>-9999</NoDataValue>
                     <timeSupport isRegular="true">
                         <unit UnitID="100">

--- a/test/test_xml/get_values_encloses_por.xml
+++ b/test/test_xml/get_values_encloses_por.xml
@@ -34,7 +34,7 @@
             <dataType>Continuous</dataType>
             <generalCategory>Water Quality</generalCategory>
             <sampleMedium>Surface Water</sampleMedium>
-            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celcius</units>
+            <units unitsAbbreviation="degC" unitsCode="96" unitsType="Temperature">degree celsius</units>
             <NoDataValue>-9999</NoDataValue>
             <timeSupport isRegular="true">
                 <unit UnitID="100">


### PR DESCRIPTION
XML's have misspelled word `celcius` changing to `celsius` should make the tests pass.