### PR TITLE
Fix some .format

### DIFF
--- a/wof/core_1_1.py
+++ b/wof/core_1_1.py
@@ -120,7 +120,7 @@ class WOF_1_1(object):
         else:
             # site = WaterML.site()
             # siteInfoResponse.add_site(site)
-            raise Exception("Site,'%s', Not Found" % siteArg)
+            raise Exception("Site {} Not Found".format(siteArg))
 
         return siteInfoResponse
 
@@ -295,7 +295,7 @@ class WOF_1_1(object):
                                                  startDateTime, endDateTime)
         # if not valueResultArr:
         #    raise Exception(
-        #        "ERROR: No data found for %s:%s for dates {} - {}".format(
+        #        "ERROR: No data found for {}:{} for dates {} - {}".format(
         #            siteCode, varCode, startDateTime, endDateTime
         #        )
         #    )
@@ -332,8 +332,10 @@ class WOF_1_1(object):
         #    return timeSeriesResponse
 
         if not valueResultArr:
-            raise Exception("Values Not Found for %s:%s for dates %s - %s" % (
-                siteCode, varCode, startDateTime, endDateTime))
+            raise Exception(
+                "Values Not Found for {}:{} for dates {} - {}".format(
+                    siteCode, varCode, startDateTime, endDateTime)
+                )
 
         if isinstance(valueResultArr, dict):
             for key in valueResultArr.keys():
@@ -628,7 +630,10 @@ class WOF_1_1(object):
         # datetime_string = core._get_datavalues_datetime(
         #  valueResult, "LocalDateTime", "DateTimeUTC")
         aDate = core._get_datavalues_datetime(
-           valueResult, "LocalDateTime", "DateTimeUTC")
+            valueResult,
+            "LocalDateTime",
+            "DateTimeUTC"
+        )
         # aDate= dateutil.parser.parse(datetime_string)
 
         if not hasattr(valueResult, 'MethodCode'):

--- a/wof/examples/flask/cbi/build_cbi_cache.py
+++ b/wof/examples/flask/cbi/build_cbi_cache.py
@@ -452,7 +452,7 @@ if __name__ == '__main__':
 
     series_set = parse_capabilities_for_series(LOCAL_CAPABILITIES_FILE_PATH)
 
-    msg = "Adding %s sites and %s variables to local cache.".format
+    msg = "Adding {} sites and {} variables to local cache.".format
     print(msg(len(cache_sites), len(cache_variables)))
 
     try:
@@ -544,4 +544,4 @@ if __name__ == '__main__':
         print("Finished.")
 
     except Exception as inst:
-        print("ERROR: %s, %s".format(type(inst), inst))
+        print("ERROR: {}, {}".format(type(inst), inst))

--- a/wof/examples/flask/cbi/cbi_sos_parser.py
+++ b/wof/examples/flask/cbi/cbi_sos_parser.py
@@ -14,7 +14,7 @@ namespaces = {
 
 
 def nspath(path, ns):
-    return '{%s}%s'.format(ns, path)
+    return '{{}}{}'.format(ns, path)
 
 
 def parse_datavalues_from_get_observation(tree, site_code, var_code):


### PR DESCRIPTION
@lsetiawan while debugging the tests I found out a few `.format` calls that still had the `%s` in them.
I fixed all those that showed up with a grep search, even a commented out one, so we can proceed with the test debug.