### PR TITLE
Use conda-forge only for extra packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,15 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda update conda --yes
   - conda config --set show_channel_urls true
-  - conda config --add channels conda-forge --force
   - conda config --add channels odm2 --force
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       conda install --yes configparser ;
     fi
+  # Coding standards and tests.
+  - conda install --yes pytest
+  - conda install --channel conda-forge --yes pycodestyle flake8-print flake8-quotes flake8-import-order flake8-builtins flake8-comprehensions flake8-mutable flake8-docstrings
 
 # Test source distribution.
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,6 @@
-pytest
+# examples
 suds-jurko
 requests
 pyodbc
-# The dependencies below are unavailable at PyPI at the moment!
+# unavailable at PyPI
 geoalchemy-odm2
-odm2api
-# Check for coding standards.
-pycodestyle
-flake8-print
-flake8-quotes
-flake8-import-order
-flake8-builtins
-flake8-comprehensions
-flake8-mutable
-flake8-docstrings


### PR DESCRIPTION
@lsetiawan and @emiliom I notice that `.travis.yml` may be used as "instructions" to get an environment for development. Because of that this PR uses the `conda-forge` channel with more care by not adding it to the `.condarc`. This ensure that people won't compromise their envs with package versions that may not be 100% compatible with `defaults` and `odm2`. (See http://conda-forge.github.io/docs/conda-forge_gotchas.html#using-multiple-channels for more info on the possible problems from mixing channels.)