### PR TITLE
Handle optional dependencies.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
-# examples
-suds-jurko
-requests
+# optional
+odm2api
 pyodbc
+requests
+sqlalchemy
+suds-jurko
+uwsgi
 # unavailable at PyPI
 geoalchemy-odm2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
-flask>=0.10.0
-lxml>=3.4.4
-spyne>=2.12.8
-python-dateutil
-jinja2
-pytz
-sqlalchemy
-odm2api
 configparser
 docopt
-uwsgi
+flask>=0.10.0
+jinja2
+lxml>=3.4.4
+python-dateutil
+pytz
+spyne>=2.12.8

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'odm1': ['sqlalchemy', 'pyodbc'],
         'odm2': ['sqlalchemy', 'odm2api'],
         'sqlite': ['sqlalchemy'],
+        'server': ['uwsgi'],
     },
     dependency_links=[
         'git+https://github.com/ODM2/ODM2PythonAPI@v0.1.0-alpha#egg=odm2api-0.1.0'  # noqa


### PR DESCRIPTION
@lsetiawan I re-organized the dependencies here to reflect the optional dependencies.
The current options are: `pip install wofpy[odm1,odm2,sqlite,server]`

Let me know if those makes sense and/or if we can merge a few of those to reduce the number of options to a minimum.