### PR TITLE
Many Changes with the timeseries dao. Now it is using odm2api.

### DIFF
--- a/test/test_odm2_dao_sqlite.py
+++ b/test/test_odm2_dao_sqlite.py
@@ -5,7 +5,8 @@ import unittest
 
 from wof.examples.flask.odm2.timeseries.odm2_timeseries_dao import Odm2Dao as OdmDao  # noqa
 
-ODM2_DATABASE_URI = 'sqlite:///' + "./test/odm2/ODM2.sqlite"
+# ODM2_DATABASE_URI = 'sqlite:///' + "./test/odm2/ODM2.sqlite"
+ODM2_DATABASE_URI = ('sqlite', './test/odm2/ODM2.sqlite')
 ODM2_ONFIG_PATH = os.path.join(
     os.path.dirname(__file__),
     'test_odm2_sqlite.cfg'
@@ -22,7 +23,7 @@ ODM2_ONFIG_PATH = os.path.join(
 class TestOdmDao(unittest.TestCase):
     def setUp(self):
         # self.dao = OdmDao(private_config.lbr_connection_string)
-        self.dao = OdmDao(ODM2_DATABASE_URI)
+        self.dao = OdmDao(*ODM2_DATABASE_URI)
         self.known_site_codes = [
             'USU-LBR-Mendon',
             # 'USU-LBR-Paradise',
@@ -288,7 +289,7 @@ class TestOdmDao(unittest.TestCase):
     def test_get_var_by_code(self):
         for known_code in self.known_var_codes:
             varResult = self.dao.get_variable_by_code(known_code)
-            self.assertEqual(known_code, varResult.VariableCode)
+            self.assertEqual(known_code, varResult[0].VariableCode)
 
     def test_get_vars_by_codes(self):
         varResultList = self.dao.get_variables_by_codes(self.known_var_codes)

--- a/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
+++ b/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
@@ -23,3 +23,10 @@ North: 42
 
 [WOFPY]
 Templates=../../../../wof/apps/templates
+
+[DATABASE]
+Engine: sqlite
+Address: ODM2.sqlite
+Db: None
+User: None
+Password: None

--- a/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
+++ b/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
@@ -1,140 +1,89 @@
 from __future__ import (absolute_import, division, print_function)
 
-from datetime import datetime
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.sql import and_
-
-from dateutil.parser import parse
+from odm2api.ODMconnection import dbconnection
+from odm2api.ODM2.services.readService import ReadODM2
+from odm2api.ODM2 import models as odm2_model
 
 from wof.dao import BaseDao
 import wof.examples.flask.odm2.timeseries.sqlalch_odm2_models as model
-from odm2api.ODM2 import models as odm2_models
-from sqlalchemy.orm import aliased
-from sqlalchemy import or_
-from sqlalchemy import and_
-from sqlalchemy.sql import func
 
-from sqlalchemy.orm import with_polymorphic
-
-import re
 
 class Odm2Dao(BaseDao):
+    def __init__(self, engine, address, db=None, user=None, password=None):
 
-    def __init__(self, db_connection_string):
-
-        self.engine = create_engine(db_connection_string, convert_unicode=True,
-            #pool_size=100
-                                    )
-        odm2_models.setSchema(self.engine)
-        # Default application pool size is 5. Use 100 to improve performance.
-        self.db_session = scoped_session(sessionmaker(
-            autocommit=False, autoflush=False, bind=self.engine))
-
-
-
-        #odm2_models.Base.query = self.db_session.query_property()
+        self.session_factory = dbconnection.createConnection(engine, address, db, user, password)
+        self.read = ReadODM2(self.session_factory)
+        self.db_session = self.session_factory.getSession()
 
     def __del__(self):
         self.db_session.close()
 
     def get_all_sites(self):
-        s_rArr = self.db_session.query(odm2_models.Sites,odm2_models.TimeSeriesResults).\
-            join(odm2_models.FeatureActions).\
-            filter(odm2_models.FeatureActions.SamplingFeatureID == odm2_models.Sites.SamplingFeatureID,
-                   odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID). \
-            group_by(odm2_models.Sites.SamplingFeatureID).all()
-        """
-        s_rArr = self.db_session.query(odm2_models.Results,
-                                       odm2_models.Sites).\
-            join(odm2_models.FeatureActions).\
-            join(odm2_models.SamplingFeatures).\
-            filter(odm2_models.SamplingFeatures.SamplingFeatureID == odm2_models.Sites.SamplingFeatureID).\
-            group_by(odm2_models.Sites.SamplingFeatureID).all()
-        """
+        s_rArr = self.read.getSamplingFeatures(type='Site')
         s_Arr = []
         for s_r in s_rArr:
-            s = model.Site(s_r.Sites)
+            s = model.Site(s_r)
             s_Arr.append(s)
+
         return s_Arr
 
     def get_site_by_code(self, site_code):
         w_s = None
         try:
-            s = self.db_session.query(odm2_models.Sites).\
-                filter(odm2_models.Sites.SamplingFeatureCode == site_code).one()
+            s = self.read.getSamplingFeatures(type='Site', codes=[site_code])
         except:
             s = None
         if s is not None:
-            w_s = model.Site(s)
+            w_s = model.Site(s[0])
         return w_s
 
     def get_sites_by_codes(self, site_codes_arr):
         s_arr = []
-        for site_code in site_codes_arr:
-            w_s = self.get_site_by_code(site_code)
-            if w_s is not None:
-                s_arr.append(w_s)
+        s_rArr = self.read.getSamplingFeatures(type='Site', codes=site_codes_arr)
+        for s in s_rArr:
+            w_s = model.Site(s)
+            s_arr.append(w_s)
         return s_arr
 
-    def get_sites_by_box(self, west,south,east,north):
+    def get_sites_by_box(self, west, south, east, north):
         """
         north - ymax - latitude
         south - ymin - latitude
         west - xmin - longitude
         east - xmax - longitude
         """
-        s_rArr = self.db_session.query(odm2_models.TimeSeriesResults,
-                                       odm2_models.Sites).\
-            join(odm2_models.FeatureActions). \
-            filter(odm2_models.FeatureActions.SamplingFeatureID == odm2_models.Sites.SamplingFeatureID,
-                   odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID,
-                   odm2_models.Sites.Latitude >= south,
-                   odm2_models.Sites.Latitude <= north,
-                   odm2_models.Sites.Longitude >= west,
-                   odm2_models.Sites.Longitude <= east).\
-            group_by(odm2_models.Sites.SamplingFeatureID).all()
+        s_rArr = []
+        s_all = self.read.getSamplingFeatures(type='Site')
+        # Perform filtering
+        for s in s_all:
+            if s.Latitude >= south and s.Latitude <= north and s.Longitude >= west and s.Longitude <= east:
+                s_rArr.append(s)
+
         s_Arr = []
         for s_r in s_rArr:
-            s = model.Site(s_r.Sites)
+            s = model.Site(s_r)
             s_Arr.append(s)
         return s_Arr
 
-    def get_variables_from_results(self,var_codes=None):
-        l_var_codes = None
-        if var_codes is not None:
-            if not isinstance(var_codes, list):
-                l_var_codes = []
-                l_var_codes.append(var_codes)
-            else:
-                l_var_codes = var_codes
-
-        r_t_Arr = []
-        if l_var_codes is None:
-            r_t = self.db_session.query(odm2_models.TimeSeriesResultValues).\
-                                        join(odm2_models.TimeSeriesResults).\
-                                        group_by(odm2_models.TimeSeriesResults.VariableID).all()
-            r_t_Arr.append(r_t)
-        else:
-            for item in l_var_codes:
-                r_t = self.db_session.query(odm2_models.TimeSeriesResultValues).\
-                        join(odm2_models.TimeSeriesResults).\
-                        join(odm2_models.Variables).\
-                        filter(odm2_models.Variables.VariableID == odm2_models.TimeSeriesResults.VariableID,
-                               odm2_models.Variables.VariableCode == item).\
-                    group_by(odm2_models.Variables.VariableID).all()
-                r_t_Arr.append(r_t)
+    def get_variables_from_results(self, var_codes=None):
         v_arr = []
-        if len(r_t_Arr) is not 0:
-            for result_t in r_t_Arr:
-                for result in result_t:
-                    v = result.ResultObj.VariableObj
-                    u = result.ResultObj.UnitsObj
-                    s = result.ResultObj.SampledMediumCV
-                    t = result.TimeAggregationIntervalUnitsObj
-                    ti = result.TimeAggregationInterval
-                    w_v = model.Variable(v,s,u,t,ti)
-                    v_arr.append(w_v)
+        # first get timeseries results
+        tsr = [r for r in self.read.getResults() if r.ResultTypeCV == 'Time series coverage']
+        if var_codes is not None:
+            tsr = [ts for ts in tsr if ts.VariableObj.VariableCode in var_codes]
+        for ts in tsr:
+            v = ts.VariableObj
+            VarSampleMedium = ts.SampledMediumCV
+            v_unit = ts.UnitsObj
+
+            r_vals = self.read.getResultValues(ts.ResultID)
+            uid = r_vals['TimeAggregationIntervalUnitsID'].unique()[0]
+
+            v_tunit = self.read.getUnits(ids=[int(uid)])[0]
+            v_timeinterval = float(r_vals['TimeAggregationInterval'].unique()[0])
+
+            w_v = model.Variable(v, VarSampleMedium, v_unit, v_tunit, v_timeinterval)
+            v_arr.append(w_v)
 
         return v_arr
 
@@ -143,142 +92,102 @@ class Odm2Dao(BaseDao):
         return v_arr
 
     def get_variable_by_code(self, var_code):
-        w_v = None
-        v_arr = self.get_variables_from_results(var_code)
-        if len(v_arr) is not 0:
-            w_v = v_arr.pop()
-        return w_v
+        v_arr = self.get_variables_from_results(var_codes=[var_code])
+        return v_arr
 
-    def get_variables_by_codes(self, var_codes_arr):
-        v_arr = self.get_variables_from_results(var_codes_arr)
+    def get_variables_by_codes(self, var_codes):
+        v_arr = self.get_variables_from_results(var_codes)
         return v_arr
 
     def get_series_by_sitecode(self, site_code):
-        r = self.db_session.query(odm2_models.TimeSeriesResults).\
-            join(odm2_models.FeatureActions).\
-            join(odm2_models.SamplingFeatures).\
-            filter(odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID,
-                   odm2_models.SamplingFeatures.SamplingFeatureCode == site_code).\
-            group_by(odm2_models.TimeSeriesResults.VariableID).all()
         r_arr = []
-        aff = None
-        for i in range(len(r)):
-            if i is 0:
-                aff = self.db_session.query(odm2_models.Affiliations).\
-                    filter(odm2_models.Affiliations.OrganizationID == r[i].FeatureActionObj.ActionObj.MethodObj.OrganizationID).first()
-            w_r = model.Series(r[i],aff)
+        tsr = [r for r in self.read.getResults() if r.ResultTypeCV == 'Time series coverage']
+        filt_tsr = [r for r in tsr if
+                    r.FeatureActionObj.SamplingFeatureObj.SamplingFeatureCode in [site_code]]
+        for r in filt_tsr:
+            aff = None
+            if r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj is not None:
+                aff = self.read.getAffiliations(
+                    orgcode=r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj.OrganizationCode)  # noqa
+            w_r = model.Series(r, aff)
             r_arr.append(w_r)
+
         return r_arr
 
     def get_series_by_sitecode_and_varcode(self, site_code, var_code):
-        r = self.db_session.query(odm2_models.TimeSeriesResults).\
-            join(odm2_models.FeatureActions).\
-            join(odm2_models.SamplingFeatures).\
-            join(odm2_models.Variables).\
-            filter(odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID,
-                   odm2_models.TimeSeriesResults.VariableID == odm2_models.Variables.VariableID,
-                   odm2_models.SamplingFeatures.SamplingFeatureCode == site_code,
-                   odm2_models.Variables.VariableCode == var_code).\
-            group_by(odm2_models.Results.VariableID).all()
         r_arr = []
-        aff = None
-        for i in range(len(r)):
-            if i is 0:
-                aff = self.db_session.query(odm2_models.Affiliations).\
-                  filter(odm2_models.Affiliations.OrganizationID == r[i].FeatureActionObj.ActionObj.MethodObj.OrganizationID).first()
-            w_r = model.Series(r[i],aff)
+        tsr = [r for r in self.read.getResults() if r.ResultTypeCV == 'Time series coverage']
+        filt_tsr = [r for r in tsr if r.FeatureActionObj.SamplingFeatureObj.SamplingFeatureCode in [
+            site_code] and r.VariableObj.VariableCode in [var_code]]  # noqa
+        for r in filt_tsr:
+            aff = None
+            if r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj is not None:
+                aff = self.read.getAffiliations(
+                    orgcode=r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj.OrganizationCode)
+            w_r = model.Series(r, aff)
             r_arr.append(w_r)
+
         return r_arr
 
-    def get_datavalues(self, site_code, var_code, begin_date_time=None,
+    def get_datavalues(self, site_code,
+                       var_code,
+                       begin_date_time=None,
                        end_date_time=None):
-
-        if (not begin_date_time or not end_date_time):
-            try:
-                valueResultArr = self.db_session.query(odm2_models.TimeSeriesResultValues).\
-                        join(odm2_models.TimeSeriesResults).\
-                        join(odm2_models.FeatureActions).\
-                        join(odm2_models.SamplingFeatures).\
-                        join(odm2_models.Variables).\
-                        filter(odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID,
-                               odm2_models.TimeSeriesResults.VariableID == odm2_models.Variables.VariableID,
-                               odm2_models.SamplingFeatures.SamplingFeatureCode == site_code,
-                               odm2_models.Variables.VariableCode == var_code).\
-                        order_by(odm2_models.TimeSeriesResultValues.ValueDateTime).all()
-            except:
-                valueResultArr = []
-        else:
-            begin_date_time = parse(begin_date_time)
-            end_date_time = parse(end_date_time)
-            try:
-                valueResultArr = self.db_session.query(odm2_models.TimeSeriesResultValues).\
-                        join(odm2_models.TimeSeriesResults).\
-                        join(odm2_models.FeatureActions).\
-                        join(odm2_models.SamplingFeatures).\
-                        join(odm2_models.Variables).\
-                        filter(odm2_models.TimeSeriesResults.FeatureActionID == odm2_models.FeatureActions.FeatureActionID,
-                               odm2_models.TimeSeriesResults.VariableID == odm2_models.Variables.VariableID,
-                               odm2_models.SamplingFeatures.SamplingFeatureCode == site_code,
-                               odm2_models.Variables.VariableCode == var_code,
-                               odm2_models.TimeSeriesResultValues.ValueDateTime >= begin_date_time,
-                               odm2_models.TimeSeriesResultValues.ValueDateTime <= end_date_time).\
-                        order_by(odm2_models.TimeSeriesResultValues.ValueDateTime).all()
-            except:
-                valueResultArr = []
-        v_arr = []
-        if len(valueResultArr) is not 0:
-            org_id = None
+        r_arr = []
+        tsr = [r for r in self.read.getResults() if r.ResultTypeCV == 'Time series coverage']
+        filt_tsr = [r for r in tsr if r.FeatureActionObj.SamplingFeatureObj.SamplingFeatureCode in [
+            site_code] and r.VariableObj.VariableCode in [var_code]]
+        for r in filt_tsr:
             aff = None
-            first_flag = True
-            for valueResult in valueResultArr:
-                if first_flag:
-                    first_flag = False
-                    org_id = valueResult.ResultObj.FeatureActionObj.ActionObj.MethodObj.OrganizationID
-                    aff = self.db_session.query(odm2_models.Affiliations).\
-                            filter(odm2_models.Affiliations.OrganizationID == org_id).first()
-                w_v = model.DataValue(valueResult,aff)
-                v_arr.append(w_v)
-        return v_arr
+            if r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj is not None:
+                aff = self.read.getAffiliations(
+                    orgcode=r.FeatureActionObj.ActionObj.MethodObj.OrganizationObj.OrganizationCode)
+            rvals = self.read.getResultValues(resultid=r.ResultID, starttime=begin_date_time,
+                                              endtime=end_date_time)
+            for i, rv in rvals.iterrows():
+                trv = self.db_session.query(odm2_model.TimeSeriesResultValues).filter_by(
+                    ValueID=rv.ValueID).one()
+                w_r = model.DataValue(trv, aff)
+                r_arr.append(w_r)
+
+        return r_arr
 
     def get_method_by_id(self, method_id):
-        m = self.db_session.query(odm2_models.Methods).\
-            filter(odm2_models.Methods.MethodID == method_id).first()
-        w_m = model.Method(m)
+        m = self.read.getMethods(ids=[method_id])
+        w_m = model.Method(m[0])
         return w_m
 
     def get_methods_by_ids(self, method_id_arr):
-        m = self.db_session.query(odm2_models.Methods).\
-            filter(odm2_models.Methods.MethodID.in_(method_id_arr)).all()
+        m = self.read.getMethods(ids=method_id_arr)
         m_arr = []
-        for i in range(len(m)):
-            w_m = model.Method(m[i])
+        for i in m:
+            w_m = model.Method(i)
             m_arr.append(w_m)
         return m_arr
 
     def get_source_by_id(self, source_id):
-        aff = self.db_session.query(odm2_models.Affiliations).\
-            filter(odm2_models.Affiliations.AffiliationID == source_id).one()
-        w_aff = model.Source(aff)
+        aff = self.read.getAffiliations(ids=[source_id])
+        w_aff = model.Source(aff[0])
         return w_aff
 
     def get_sources_by_ids(self, source_id_arr):
-        aff = self.db_session.query(odm2_models.Affiliations).\
-            filter(odm2_models.Affiliations.AffiliationID.in_(source_id_arr)).all()
+        aff = self.read.getAffiliations(ids=source_id_arr)
         aff_arr = []
-        for i in range(len(aff)):
-            w_a = model.Source(aff[i])
+        for a in aff:
+            w_a = model.Source(a)
             aff_arr.append(w_a)
         return aff_arr
 
     def get_qualcontrollvl_by_id(self, qual_control_lvl_id):
-        pl = self.db_session.query(odm2_models.ProcessingLevels)\
-            .filter(odm2_models.ProcessingLevels.ProcessingLevelID == qual_control_lvl_id).first()
+        pl = self.db_session.query(odm2_model.ProcessingLevels) \
+            .filter(odm2_model.ProcessingLevels.ProcessingLevelID == qual_control_lvl_id).first()
         w_pl = model.QualityControlLevel(pl)
         return w_pl
 
     def get_qualcontrollvls_by_ids(self, qual_control_lvl_id_arr):
-        pl = self.db_session.query(odm2_models.ProcessingLevels)\
-            .filter(odm2_models.ProcessingLevels.ProcessingLevelID.in_(qual_control_lvl_id_arr)).all()
+        pl = self.db_session.query(odm2_model.ProcessingLevels) \
+            .filter(
+            odm2_model.ProcessingLevels.ProcessingLevelID.in_(qual_control_lvl_id_arr)).all()
         pl_arr = []
         for i in range(len(pl)):
             w_pl = model.QualityControlLevel(pl[i])

--- a/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
+++ b/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
@@ -1,29 +1,35 @@
 from __future__ import (absolute_import, division, print_function)
 
-import os, sys
+import configparser
 
-import wof.flask
-
-import logging
 import wof
-
+import wof.flask
 from wof.examples.flask.odm2.timeseries.odm2_timeseries_dao import Odm2Dao
 #import private_config
 
 """
     python runserver_odm2_timeseries.py
     --config=odm2_config_timeseries.cfg
-    --connection=example.connection
 
 """
 #logging.basicConfig(level=logging.DEBUG)
 #logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
 
 
-def startServer(config='odm2_config_timeseries.cfg',connection=None,
+def startServer(conf='odm2_config_timeseries.cfg',
                     openPort = 8080):
-    dao = Odm2Dao(connection.read())
-    app = wof.flask.create_wof_flask_app(dao, config)
+
+    config = configparser.ConfigParser()
+    with open(conf, 'r') as configfile:
+        config.read_file(configfile)
+        connection = (config['DATABASE']['Engine'],
+                      config['DATABASE']['Address'],
+                      config['DATABASE']['Db'],
+                      config['DATABASE']['User'],
+                      config['DATABASE']['Password'])
+
+    dao = Odm2Dao(*connection)
+    app = wof.flask.create_wof_flask_app(dao, conf)
     app.config['DEBUG'] = True
 
 
@@ -43,12 +49,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='start WOF for an ODM2 database.')
     parser.add_argument('--config',
                        help='Configuration file', default='odm2_config_timeseries.cfg')
-    parser.add_argument('--connection',type=argparse.FileType('r'),
-                       help='The name of a file containing the Connection String eg: private.connection which has: mysql://username:password@localhost/database')
 
     parser.add_argument('--port',
                        help='Open port for server."', default=8080, type=int)
     args = parser.parse_args()
     print(args)
 
-    startServer(config=args.config,connection=args.connection,openPort=args.port)
+    startServer(conf=args.config, openPort=args.port)


### PR DESCRIPTION
Many Changes with the timeseries dao. Now it is using odm2api to do the queries and such. Also, implementation of DB configuration have started, now runserver.py reads from `.cfg` for DATABASE config. 

**NOTE: There are still some issues that needs to be addressed, such as error below when `WOFpy` is running**

```bash
Error running Query: (sqlite3.ProgrammingError) SQLite objects created in a thread can only be used in that same thread.The object was created in thread id 139731677263616 and this is thread id 139731685656320...
```
*I'll open up issue in a bit.. this pull request is mostly for me to see if `odm2_dao_sqlite_test` passes, due to the huge changes that is about to happen on the `ODM2PythonAPI` side, I would not merge yet.* Thanks.