### PR TITLE
Implement database string connection in configfile

### DIFF
--- a/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
+++ b/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
@@ -3,7 +3,7 @@ Network: ODM2Timeseries
 Vocabulary: ODM2Timeseries
 Menu_Group_Name: ODM2
 Service_WSDL: http://127.0.0.1:8080/soap/wateroneflow.wsdl
-Timezone:00:00
+Timezone: 00:00
 TimezoneAbbreviation: GMT
 
 [Default_Params]
@@ -22,4 +22,8 @@ East: -110
 North: 42
 
 [WOFPY]
-Templates=../../../../wof/apps/templates
+Templates: ../../../../wof/apps/templates
+
+[Database]
+# The name of a file containing the Connection String eg: private.connection which has: mysql://username:password@localhost/database
+Connection_String: sqlite:///../../../../test/odm2/ODM2.sqlite

--- a/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
+++ b/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
@@ -23,7 +23,7 @@ def startServer(conf='odm2_config_timeseries.cfg', openPort = 8080):
         connection = config['Database']['Connection_String']
 
     dao = Odm2Dao(connection)
-    app = wof.flask.create_wof_flask_app(dao, config)
+    app = wof.flask.create_wof_flask_app(dao, conf)
     app.config['DEBUG'] = True
 
 

--- a/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
+++ b/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
@@ -1,28 +1,28 @@
 from __future__ import (absolute_import, division, print_function)
 
-import os, sys
+import argparse
 
-import wof.flask
+import configparser
 
-import logging
 import wof
-
+import wof.flask
 from wof.examples.flask.odm2.timeseries.odm2_timeseries_dao import Odm2Dao
-#import private_config
 
 """
     python runserver_odm2_timeseries.py
     --config=odm2_config_timeseries.cfg
-    --connection=example.connection
 
 """
-#logging.basicConfig(level=logging.DEBUG)
-#logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
 
+def startServer(conf='odm2_config_timeseries.cfg', openPort = 8080):
 
-def startServer(config='odm2_config_timeseries.cfg',connection=None,
-                    openPort = 8080):
-    dao = Odm2Dao(connection.read())
+    # Parse connection from config file
+    config = configparser.ConfigParser()
+    with open(conf, 'r') as configfile:
+        config.read_file(configfile)
+        connection = config['Database']['Connection_String']
+
+    dao = Odm2Dao(connection)
     app = wof.flask.create_wof_flask_app(dao, config)
     app.config['DEBUG'] = True
 
@@ -38,17 +38,13 @@ def startServer(config='odm2_config_timeseries.cfg',connection=None,
     app.run(host='0.0.0.0', port=openPort, threaded=True)
 
 if __name__ == '__main__':
-    import argparse
 
     parser = argparse.ArgumentParser(description='start WOF for an ODM2 database.')
     parser.add_argument('--config',
                        help='Configuration file', default='odm2_config_timeseries.cfg')
-    parser.add_argument('--connection',type=argparse.FileType('r'),
-                       help='The name of a file containing the Connection String eg: private.connection which has: mysql://username:password@localhost/database')
-
     parser.add_argument('--port',
                        help='Open port for server."', default=8080, type=int)
     args = parser.parse_args()
     print(args)
 
-    startServer(config=args.config,connection=args.connection,openPort=args.port)
+    startServer(conf=args.config, openPort=args.port)


### PR DESCRIPTION
This pull request would grab database connection information from configfile during runserver, eliminating `--connection` option that was previously there. I've also cleaned up the runserver code a bit, eliminating unused imports.