### PR TITLE
Modified runserver to be able to use in production

### DIFF
--- a/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
+++ b/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
@@ -4,7 +4,6 @@ import argparse
 
 import configparser
 
-import wof
 import wof.flask
 from wof.examples.flask.odm2.timeseries.odm2_timeseries_dao import Odm2Dao
 
@@ -15,19 +14,29 @@ from wof.examples.flask.odm2.timeseries.odm2_timeseries_dao import Odm2Dao
 """
 
 
-def startServer(conf='odm2_config_timeseries.cfg', openPort=8080):
-
+def get_connection(conf):
     # Parse connection from config file
     config = configparser.ConfigParser()
     with open(conf, 'r') as configfile:
         config.read_file(configfile)
         connection = config['Database']['Connection_String']
+        return connection
 
-    dao = Odm2Dao(connection)
-    app = wof.flask.create_wof_flask_app(dao, conf)
+parser = argparse.ArgumentParser(description='start WOF for an ODM2 database.')
+parser.add_argument('--config',
+                   help='Configuration file', default='odm2_config_timeseries.cfg')
+parser.add_argument('--port',
+                   help='Open port for server."', default=8080, type=int)
+args = parser.parse_args()
+print(args)
+
+dao = Odm2Dao(get_connection(args.config))
+app = wof.flask.create_wof_flask_app(dao, args.config)
+
+if __name__ == '__main__':
     app.config['DEBUG'] = True
 
-    url = "http://127.0.0.1:" + str(openPort)
+    url = "http://127.0.0.1:" + str(args.port)
     print("----------------------------------------------------------------")
     print("Access Service endpoints at ")
     for path in wof.site_map(app):
@@ -35,16 +44,4 @@ def startServer(conf='odm2_config_timeseries.cfg', openPort=8080):
 
     print("----------------------------------------------------------------")
 
-    app.run(host='0.0.0.0', port=openPort, threaded=True)
-
-if __name__ == '__main__':
-
-    parser = argparse.ArgumentParser(description='start WOF for an ODM2 database.')
-    parser.add_argument('--config',
-                       help='Configuration file', default='odm2_config_timeseries.cfg')
-    parser.add_argument('--port',
-                       help='Open port for server."', default=8080, type=int)
-    args = parser.parse_args()
-    print(args)
-
-    startServer(conf=args.config, openPort=args.port)
+    app.run(host='0.0.0.0', port=args.port, threaded=True)

--- a/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
+++ b/wof/examples/flask/odm2/timeseries/runserver_odm2_timeseries.py
@@ -20,7 +20,8 @@ def get_connection(conf):
     with open(conf, 'r') as configfile:
         config.read_file(configfile)
         connection = config['Database']['Connection_String']
-        return connection
+
+    return connection
 
 parser = argparse.ArgumentParser(description='start WOF for an ODM2 database.')
 parser.add_argument('--config',
@@ -28,7 +29,6 @@ parser.add_argument('--config',
 parser.add_argument('--port',
                    help='Open port for server."', default=8080, type=int)
 args = parser.parse_args()
-print(args)
 
 dao = Odm2Dao(get_connection(args.config))
 app = wof.flask.create_wof_flask_app(dao, args.config)


### PR DESCRIPTION
I modified the odm2 timeseries runserver, so that I can use for both development and production. @ocefpaf Let me know if I'm breaking Pep8 and if I do, how can I do better? Basically I need to get the app variable for wsgi to use, and the `argparse` stuff is for development user input. Thanks.