### PR TITLE
Update dao and WOF models for odm2timeseries

### DIFF
--- a/wof/examples/flask/odm2/timeseries/sqlalch_odm2_models.py
+++ b/wof/examples/flask/odm2/timeseries/sqlalch_odm2_models.py
@@ -114,11 +114,16 @@ class Series(wof_base.BaseSeries):
         # self.MethodID = m_obj.MethodID
         # self.MethodDescription = m_obj.MethodDescription
         self.Method = Method(m_obj)
+        #
         if o_obj is not None:
             self.Organization = o_obj.OrganizationName
+
         self.BeginDateTimeUTC = a_obj.BeginDateTime.isoformat()
         if a_obj.EndDateTime is not None:
             self.EndDateTimeUTC = a_obj.EndDateTime.isoformat()
+        else:
+            self.EndDateTimeUTC = r.tsrv_EndDateTime.isoformat()
+
         self.ValueCount = r.ValueCount
         if aff is not None:
             self.Source = Source(aff)


### PR DESCRIPTION
This updates the `odm2timeseries` DAO and WOF model definitions to work with Postgresql in addition to MySQL and SQLite. Improvements are needed, definitely not perfect, but currently it works. 