### PR TITLE
encoding/decoding test

### DIFF
--- a/test/test_dao_1_1.py
+++ b/test/test_dao_1_1.py
@@ -1,0 +1,583 @@
+# coding=utf-8
+
+from __future__ import (absolute_import, division, print_function)
+
+from datetime import MAXYEAR, MINYEAR, datetime, timedelta
+
+from dateutil.parser import parse
+
+from wof import dao, models
+
+
+class TestSite(models.BaseSite):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestSpatialReference(models.BaseSpatialReference):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestVariable(models.BaseVariable):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestUnits(models.BaseUnits):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestSeries(models.BaseSeries):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestMethod(models.BaseMethod):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestMetadata(models.BaseMetadata):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestSource(models.BaseSource):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestQualifier(models.BaseQualifier):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestOffsetType(models.BaseOffsetType):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestDataValue(models.BaseDataValue):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+test_spatialrefs = {
+    'NAD83': TestSpatialReference(
+        SpatialReferenceId=2,
+        SRSID='4269',
+        SRSName='NAD83',
+        Notes='spatial ref note'),
+    'UTM12N': TestSpatialReference(
+        SpatialReferenceId=105,
+        SRSID='26912',
+        SRSName='NAD83 / UTM zone 12N',
+        Notes=None)
+    }
+
+test_sites = {
+    'SITE_A': TestSite(
+        SiteID=1,
+        SiteCode='SITE_A',
+        SiteName='Site A',
+        Latitude=50,
+        Longitude=60),
+    'SITE_B': TestSite(
+        SiteID=2,
+        SiteCode='SITE_B',
+        SiteName='Site B',
+        Latitude=41.718473,
+        Longitude=-111.946402,
+        LatLongDatumID=2,
+        Elevation_m=12.3,
+        VerticalDatum='NGVD29',
+        LocalX=421276.323,
+        LocalY=4618952.04,
+        LocalProjectionID=105,
+        State='Utah',
+        County='Cache',
+        Comments='Located in a neat place',
+        LatLongDatum=test_spatialrefs['NAD83'],
+        LocalProjection=test_spatialrefs['UTM12N']),
+    'SITE_C': TestSite(
+        SiteID=3,
+        SiteCode='SITE_C',
+        SiteName='Site C',
+        Latitude=59,
+        Longitude=10),
+    'SITE_N': TestSite(
+        SiteID=4,
+        SiteCode='SITE_N',
+        SiteName='Site ñ',
+        Latitude=59,
+        Longitude=20)
+    }
+
+test_units = {
+    96: TestUnits(
+        UnitsID=96,
+        UnitsName='degree celsius',
+        UnitsType='Temperature',
+        UnitsAbbreviation='°C'),
+    100: TestUnits(
+        UnitsID=100,
+        UnitsName='second',
+        UnitsType='Time',
+        UnitsAbbreviation='s'),
+    35: TestUnits(
+        UnitsID=35,
+        UnitsName='cubic feet per second',
+        UnitsType='Flow',
+        UnitsAbbreviation='cfs'),
+    102: TestUnits(
+        UnitsID=102,
+        UnitsName='minute',
+        UnitsType='Time',
+        UnitsAbbreviation='min'),
+    199: TestUnits(
+        UnitsID=199,
+        UnitsName='milligrams per liter',
+        UnitsType='Concentration',
+        UnitsAbbreviation='mg/L'),
+    52: TestUnits(
+        UnitsID=52,
+        UnitsName='meter',
+        UnitsType='Length',
+        UnitsAbbreviation='m'),
+    }
+
+test_variables = {
+    'Temp': TestVariable(
+        VariableID=1,
+        VariableCode='Temp',
+        VariableName='Temperature',
+        VariableUnitsID=96,
+        VariableUnits=test_units[96],
+        SampleMedium='Surface Water',
+        ValueType='Field Observation',
+        IsRegular=True,
+        TimeSupport=0,
+        TimeUnitsID=100,
+        TimeUnits=test_units[100],
+        DataType='Continuous',
+        GeneralCategory='Water Quality',
+        NoDataValue=-9999,
+        VariableDescription=None),
+    'Flow': TestVariable(
+        VariableID=2,
+        VariableCode='Flow',
+        VariableName='Discharge',
+        VariableUnitsID=35,
+        VariableUnits=test_units[35],
+        SampleMedium='Surface Water',
+        ValueType='Field Observation',
+        IsRegular=True,
+        TimeSupport=15,
+        TimeUnitsID=102,
+        TimeUnits=test_units[102],
+        DataType='Average',
+        GeneralCategory='Hydrology',
+        NoDataValue=-9999,
+        VariableDescription='Average streamflow'),
+    'TP': TestVariable(
+        VariableID=3,
+        VariableCode='TP',
+        VariableName='Phosphorus, total as P',
+        VariableUnitsID=199,
+        VariableUnits=test_units[199],
+        SampleMedium='Surface Water',
+        ValueType='Sample',
+        IsRegular=False,
+        TimeSupport=0,
+        TimeUnitsID=100,
+        TimeUnits=test_units[100],
+        DataType='Sporadic',
+        GeneralCategory='Water Quality',
+        NoDataValue=-9999,
+        VariableDescription=None)
+    }
+
+test_methods = {
+    5: TestMethod(
+        MethodID=5,
+        MethodDescription='Temperature measured using a sensor.',
+        MethodLink='http://www.campbellsci.com/'),
+    26: TestMethod(
+        MethodID=26,
+        MethodDescription='USGS real time streamflow gage.',
+        MethodLink='http://waterdata.usgs.gov'),
+    25: TestMethod(
+        MethodID=25,
+        MethodDescription='Grab sample collected by smurfs in the field.',
+        MethodLink=None),
+    27: TestMethod(
+        MethodID=27,
+        MethodDescription='Coge la muestra del árbol.',
+        MethodLink=None)
+    }
+
+test_metadata = {
+    1: TestMetadata(
+        MetadataID=1,
+        TopicCategory='inlandWaters',
+        Title='Good Title',
+        Abstract='Nice Abstract',
+        ProfileVersion='Unknown',
+        MetadataLink='http://www.unknown.edu'),
+    2: TestMetadata(
+            MetadataID=2,
+            TopicCategory='inlandWaters',
+            Title='El océano',
+            Abstract='Algunos resumen sobre el océano.',
+            ProfileVersion='Unknown',
+            MetadataLink='http://www.unknown.edu')
+    }
+
+test_sources = {
+    1: TestSource(
+        SourceID=1,
+        Organization='Thundercats',
+        SourceDescription='Likes defeating evil; also likes milk',
+        SourceLink='http://www.thundercats.edu',
+        ContactName='Snarf',
+        Phone='555-555-5555',
+        Email='snarf@gocats.outerspace',
+        Address='Thundercats Lair',
+        City='Meow City',
+        State='Thundera',
+        ZipCode='23487',
+        MetadataID=1,
+        Metadata=test_metadata[1]),
+    2: TestSource(
+            SourceID=2,
+            Organization='Université Pierre et Marie Curie',
+            SourceDescription='Public research university and was established in 1971',
+            SourceLink='http://www.upmc.fr/en/',
+            ContactName='Snarf',
+            Phone='555-555-5555',
+            Email='snarf@gocats.outerspace',
+            Address='Thundercats Lair',
+            City='Meow City',
+            State='Thundera',
+            ZipCode='23487',
+            MetadataID=2,
+            Metadata=test_metadata[2])
+    }
+
+test_series = {
+    'Temp': TestSeries(
+        SeriesID=1,
+        Site=test_sites['SITE_A'],
+        SiteID=test_sites['SITE_A'].SiteID,
+        SiteCode=test_sites['SITE_A'].SiteCode,
+        SiteName=test_sites['SITE_A'].SiteName,
+        Variable=test_variables['Temp'],
+        VariableID=test_variables['Temp'].VariableID,
+        VariableCode=test_variables['Temp'].VariableCode,
+        VariableName=test_variables['Temp'].VariableName,
+        VariableUnitsID=test_variables['Temp'].VariableUnitsID,
+        VariableUnitsName=test_units[96].UnitsName,
+        SampleMedium=test_variables['Temp'].SampleMedium,
+        ValueType=test_variables['Temp'].ValueType,
+        TimeSupport=test_variables['Temp'].TimeSupport,
+        TimeUnitsID=test_variables['Temp'].TimeUnitsID,
+        TimeUnitsName=test_variables['Temp'].TimeUnits.UnitsName,
+        DataType=test_variables['Temp'].DataType,
+        GeneralCategory=test_variables['Temp'].GeneralCategory,
+        Method=test_methods[5],
+        MethodID=test_methods[5].MethodID,
+        MethodDescription=test_methods[5].MethodDescription,
+        Source=test_sources[1],
+        SourceID=test_sources[1].SourceID,
+        Organization=test_sources[1].Organization,
+        SourceDescription=test_sources[1].SourceDescription,
+        QualityControlLevelID=1,
+        QualityControlLevelCode="QC'd",
+        BeginDateTime=parse('2007-04-05T00:00-06'),
+        EndDateTime=parse('2007-04-06T00:00-06'),
+        BeginDateTimeUTC=parse('2007-04-05T06:00Z'),
+        EndDateTimeUTC=parse('2007-04-06T06:00Z'),
+        ValueCount=2),
+    'Flow': TestSeries(
+        SeriesID=2,
+        Site=test_sites['SITE_A'],
+        SiteID=test_sites['SITE_A'].SiteID,
+        SiteCode=test_sites['SITE_A'].SiteCode,
+        SiteName=test_sites['SITE_A'].SiteName,
+        Variable=test_variables['Flow'],
+        VariableID=test_variables['Flow'].VariableID,
+        VariableCode=test_variables['Flow'].VariableCode,
+        VariableName=test_variables['Flow'].VariableName,
+        VariableUnitsID=test_variables['Flow'].VariableUnitsID,
+        VariableUnitsName=test_units[35].UnitsName,
+        SampleMedium=test_variables['Flow'].SampleMedium,
+        ValueType=test_variables['Flow'].ValueType,
+        TimeSupport=test_variables['Flow'].TimeSupport,
+        TimeUnitsID=test_variables['Flow'].TimeUnitsID,
+        TimeUnitsName=test_variables['Flow'].TimeUnits.UnitsName,
+        DataType=test_variables['Flow'].DataType,
+        GeneralCategory=test_variables['Flow'].GeneralCategory,
+        Method=test_methods[26],
+        MethodID=test_methods[26].MethodID,
+        MethodDescription=test_methods[26].MethodDescription,
+        Source=test_sources[1],
+        SourceID=test_sources[1].SourceID,
+        Organization=test_sources[1].Organization,
+        SourceDescription=test_sources[1].SourceDescription,
+        QualityControlLevelID=1,
+        QualityControlLevelCode="QC'd",
+        BeginDateTime=parse('2007-04-05T00:00-06'),
+        EndDateTime=parse('2007-04-05T00:00-06'),
+        BeginDateTimeUTC=parse('2007-04-05T06:00Z'),
+        EndDateTimeUTC=parse('2007-04-05T06:00Z'),
+        ValueCount=1),
+    'TP': TestSeries(
+        SeriesID=3,
+        Site=test_sites['SITE_B'],
+        SiteID=test_sites['SITE_B'].SiteID,
+        SiteCode=test_sites['SITE_B'].SiteCode,
+        SiteName=test_sites['SITE_B'].SiteName,
+        Variable=test_variables['TP'],
+        VariableID=test_variables['TP'].VariableID,
+        VariableCode=test_variables['TP'].VariableCode,
+        VariableName=test_variables['TP'].VariableName,
+        VariableUnitsID=test_variables['TP'].VariableUnitsID,
+        VariableUnitsName=test_units[199].UnitsName,
+        SampleMedium=test_variables['TP'].SampleMedium,
+        ValueType=test_variables['TP'].ValueType,
+        TimeSupport=test_variables['TP'].TimeSupport,
+        TimeUnitsID=test_variables['TP'].TimeUnitsID,
+        TimeUnitsName=test_variables['TP'].TimeUnits.UnitsName,
+        DataType=test_variables['TP'].DataType,
+        GeneralCategory=test_variables['TP'].GeneralCategory,
+        Method=test_methods[25],
+        MethodID=test_methods[25].MethodID,
+        MethodDescription=test_methods[25].MethodDescription,
+        Source=test_sources[1],
+        SourceID=test_sources[1].SourceID,
+        Organization=test_sources[1].Organization,
+        SourceDescription=test_sources[1].SourceDescription,
+        QualityControlLevelID=1,
+        QualityControlLevelCode="QC'd",
+        BeginDateTime=parse('2007-04-05T00:00-06'),
+        EndDateTime=parse('2007-04-06T00:00-06'),
+        BeginDateTimeUTC=parse('2007-04-05T06:00Z'),
+        EndDateTimeUTC=parse('2007-04-06T06:00Z'),
+        ValueCount=2)
+    }
+
+test_qualifiers = {
+    1: TestQualifier(
+        QualifierID=1,
+        QualifierCode='USU-I',
+        QualifierDescription='Value made up from thin air')
+    }
+
+test_offset_types = {
+    1: TestOffsetType(
+        OffsetTypeID=1,
+        OffsetUnitsID=test_units[52].UnitsID,
+        OffsetDescription='Distance below water surface',
+        OffsetUnits=test_units[52])
+    }
+
+test_datavalues = {
+    'Temp1': TestDataValue(
+        ValueID=1,
+        DataValue=8.4,
+        ValueAccuracy=None,
+        LocalDateTime=parse('2007-04-05T00:00-06'),
+        UTCOffset=-6,
+        DateTimeUTC=parse('2007-04-05T06:00Z'),
+        SiteID=1,
+        VariableID=1,
+        OffsetValue=2.4,
+        OffsetTypeID=1,
+        CensorCode='nc',
+        QualifierID=None,
+        MethodID=5,
+        SourceID=1,
+        SampleID=None,
+        QualityControlLevel='Quality controlled data',
+        QualityControlLevelID=1),
+    'Temp2': TestDataValue(
+        ValueID=2,
+        DataValue=10.4,
+        ValueAccuracy=None,
+        LocalDateTime=parse('2007-04-06T00:00-06'),
+        UTCOffset=-6,
+        DateTimeUTC=parse('2007-04-06T06:00Z'),
+        SiteID=1,
+        VariableID=1,
+        OffsetValue=2.5,
+        OffsetTypeID=1,
+        CensorCode='nc',
+        QualifierID=1,
+        MethodID=5,
+        SourceID=1,
+        SampleID=None,
+        QualityControlLevel='Quality controlled data',
+        QualityControlLevelID=1),
+    'Flow1': TestDataValue(
+        ValueID=3,
+        DataValue=110.2,
+        ValueAccuracy=.8,
+        LocalDateTime=parse('2007-04-05T00:00-06'),
+        UTCOffset=-6,
+        DateTimeUTC=parse('2007-04-05T06:00Z'),
+        SiteID=1,
+        VariableID=2,
+        OffsetValue=None,
+        OffsetTypeID=None,
+        CensorCode='nc',
+        QualifierID=None,
+        MethodID=26,
+        SourceID=1,
+        SampleID=None,
+        QualityControlLevel='QC Definition',
+        QualityControlLevelID=1),
+    'TP1': TestDataValue(
+        ValueID=4,
+        DataValue=.02,
+        ValueAccuracy=None,
+        LocalDateTime=parse('2007-04-05T00:00-06'),
+        UTCOffset=-6,
+        DateTimeUTC=parse('2007-04-05T06:00Z'),
+        SiteID=2,
+        VariableID=3,
+        OffsetValue=None,
+        OffsetTypeID=None,
+        CensorCode='nc',
+        QualifierID=None,
+        MethodID=25,
+        SourceID=1,
+        SampleID=None,
+        QualityControlLevel='Quality controlled data',
+        QualityControlLevelID=1),
+    'TP2': TestDataValue(
+        ValueID=5,
+        DataValue=.05,
+        ValueAccuracy=None,
+        LocalDateTime=parse('2007-04-06T00:00-06'),
+        UTCOffset=-6,
+        DateTimeUTC=parse('2007-04-06T06:00Z'),
+        SiteID=2,
+        VariableID=3,
+        OffsetValue=None,
+        OffsetTypeID=None,
+        CensorCode='nc',
+        QualifierID=None,
+        MethodID=25,
+        SourceID=1,
+        SampleID=101,
+        QualityControlLevel='QC Definition',
+        QualityControlLevelID=1)
+    }
+
+
+class TestDao(dao.BaseDao):
+    def get_all_sites(self):
+        return list(test_sites.values())
+
+    def get_sites_by_codes(self, site_codes):
+        return [test_sites[site_code] for site_code in site_codes]
+
+    def get_all_variables(self):
+        return list(test_variables.values())
+
+    def get_variable_by_code(self, variable_code):
+        return self.get_variables_by_codes([variable_code])[0]
+
+    def get_variables_by_codes(self, variable_codes):
+        return [test_variables[var_code] for var_code in variable_codes]
+
+    def get_site_by_code(self, site_code):
+        return test_sites[site_code]
+
+    def get_series_by_sitecode(self, site_code):
+        series_catalog = test_series.items()
+        return [v for k, v in series_catalog if v.SiteCode == site_code]
+
+    def get_series_by_sitecode_and_varcode(self, site_code, var_code):
+        series_catalog = test_series.items()
+        return [v for k, v in series_catalog if v.SiteCode == site_code and
+                v.VariableCode == var_code]
+
+    def get_utc_datetime(self, date_string):
+        local_date = parse(date_string)
+        utc_time_zone = parse('2001-01-01T00Z').tzinfo
+        if local_date.tzinfo:
+            return local_date.astimezone(utc_time_zone)
+        else:
+            # No time zone supplied.  Assume local time (UTC-6)
+            local_date = local_date + timedelta(hours=6)
+            return local_date.replace(tzinfo=utc_time_zone)
+
+    def datavalue_in_date_range(self, datavalue, begin_date_time,
+                                end_date_time):
+
+        if not begin_date_time:
+            start_date = parse(datetime(MINYEAR, 1, 1).isoformat() + 'Z')
+        else:
+            start_date = self.get_utc_datetime(begin_date_time)
+        if not end_date_time:
+            end_date = parse(datetime(MAXYEAR, 12, 31).isoformat() + 'Z')
+        else:
+            end_date = self.get_utc_datetime(end_date_time)
+
+        value_time = datavalue.DateTimeUTC
+
+        return (value_time >= start_date and value_time <= end_date)
+
+    def get_datavalues(self, site_code, var_code, begin_date_time=None,
+                       end_date_time=None):
+        vals = test_datavalues.items()
+        site_id = test_sites[site_code].SiteID
+        var_id = test_variables[var_code].VariableID
+        vals = [v for k, v in vals if v.SiteID == site_id and
+                v.VariableID == var_id and
+                self.datavalue_in_date_range(v,
+                                             begin_date_time,
+                                             end_date_time)]
+        import operator
+        vals.sort(key=operator.attrgetter('DateTimeUTC'))
+        return vals
+
+    def get_methods_by_ids(self, method_id_arr):
+        return [test_methods[id] for id in method_id_arr]
+
+    def get_sources_by_ids(self, source_id_arr):
+        return [test_sources[id] for id in source_id_arr]
+
+    def get_qualifiers_by_ids(self, qualifier_id_arr):
+        return [test_qualifiers[id] for id in qualifier_id_arr]
+
+    def get_offsettypes_by_ids(self, offset_type_id_arr):
+        return [test_offset_types[id] for id in offset_type_id_arr]
+
+    def get_qualcontrollvl_by_id(self, qual_control_lvl_id):
+        qcl = models.BaseQualityControlLevel()
+        qcl.QualityControlLevelCode = "Quality controlled data"
+        qcl.Definition = "Quality controlled data"
+        qcl.QualityControlLevelID = 1
+        return [qcl]
+
+    def get_qualcontrollvls_by_ids(self, qual_control_lvl_id):
+        qcl = models.BaseQualityControlLevel()
+        qcl.QualityControlLevelCode = "Quality controlled data"
+        qcl.Definition = "Quality controlled data"
+        qcl.QualityControlLevelID = 1
+        return [qcl]

--- a/test/test_wof_1_1.py
+++ b/test/test_wof_1_1.py
@@ -1,0 +1,185 @@
+from __future__ import (absolute_import, division, print_function)
+
+import io
+import os
+import unittest
+
+from lxml import etree, objectify
+
+from test_dao_1_1 import TestDao
+
+from wof import WOF_1_1 as WOF
+import wof.utils
+
+TEST_CONFIG_FILE = 'test_config.cfg'
+TEST_XML_DIR = 'test_xml'
+
+NSDEF = 'xmlns:gml="http://www.opengis.net/gml" \
+    xmlns:xlink="http://www.w3.org/1999/xlink" \
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" \
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \
+    xmlns:wtr="http://www.cuahsi.org/waterML/" \
+    xmlns="http://www.cuahsi.org/waterML/1.1/"'
+
+
+class TestWOF(unittest.TestCase):
+    """
+    Tests wof response generation methods for validation against
+    the WaterML 1.1 schema.
+    """
+
+    def setUp(self):
+        dao = TestDao()
+        testConfig = os.path.join(os.path.dirname(__file__), TEST_CONFIG_FILE)
+        self.wof_inst = WOF(dao, testConfig)
+
+        if not os.path.exists(os.path.join(os.path.abspath(os.path.curdir), 'watermlcvs.json')):
+            wof.utils.update_watermlcvs()
+
+        waterml_schema_path = os.path.join(
+            os.path.dirname(__file__),
+            'cuahsiTimeSeries_v1_1.xsd'
+        )
+        waterml_schema_doc = etree.parse(waterml_schema_path)
+        self.waterml_schema = etree.XMLSchema(waterml_schema_doc)
+
+    def response_to_StringIO(self, response, root_name):
+        """
+        Converts WOF method response to StringIO object.
+        """
+        response_output = io.BytesIO()
+        response.export(response_output, 0, name_=root_name,
+                        namespacedef_=NSDEF)
+
+        return response_output.getvalue()
+
+    def save_response(self, response, filename, root_name):
+        f = open(filename, 'w')
+        response.export(f, 0, name_=root_name,
+                        namespacedef_=NSDEF)
+        f.close()
+
+    # Preserved in case in the future will do xml comparison test for WaterML 1.1.
+    # def compare_output_to_known_xml(self,
+    #                                 response_stringIO,
+    #                                 known_xml_filename):
+    #     """
+    #     Make sure response output is as expected. This tests that a
+    #     response contains the same XML as in the known XML file.
+    #     """
+    #     known_file_path = os.path.join(os.path.dirname(__file__),
+    #                                    TEST_XML_DIR, known_xml_filename)
+    #     # Use objectify and etree to remove whitespace from XML for comparison
+    #     response_tree = objectify.fromstring(response_stringIO)
+    #     print('---------------------')
+    #     try:
+    #         print(response_tree.queryInfo.creationTime)
+    #         response_tree.queryInfo.creationTime = 'dateTime'
+    #     except:
+    #         pass
+    #     known_tree = objectify.parse(known_file_path)
+    #     response_string = etree.tostring(response_tree)
+    #     known_string = etree.tostring(known_tree)
+    #     # print(response_string)
+    #     assert response_string == known_string
+
+    def test_get_all_sites(self):
+        response = self.wof_inst.create_get_site_response()
+        response_string = self.response_to_StringIO(response,
+                                                    'sitesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_all_sites_1_1.xml')
+
+    def test_get_one_site(self):
+        response = self.wof_inst.create_get_site_response(
+            'TEST:SITE_A')
+        response_string = self.response_to_StringIO(response,
+                                                    'sitesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_one_site_1_1.xml')
+
+    def test_get_multiple_sites(self):
+        response = self.wof_inst.create_get_site_response(
+            'TEST:SITE_A,TEST:SITE_B')
+        response_string = self.response_to_StringIO(response,
+                                                    'sitesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_multiple_sites_1_1.xml')
+
+    def test_get_all_variables(self):
+        response = self.wof_inst.create_get_variable_info_response()
+        response_string = self.response_to_StringIO(response,
+                                                    'variablesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_all_variables_1_1.xml')
+
+    def test_get_one_variable(self):
+        response = self.wof_inst.create_get_variable_info_response(
+            'TESTVocab:Temp')
+        response_string = self.response_to_StringIO(response,
+                                                    'variablesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_one_variable_1_1.xml')
+
+    def test_get_multiple_variables(self):
+        response = self.wof_inst.create_get_variable_info_response(
+            'TESTVocab:Flow,TESTVocab:TP')
+        response_string = self.response_to_StringIO(response,
+                                                    'variablesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_multiple_variables_1_1.xml')
+
+    def test_get_site_info_novar(self):
+        response = self.wof_inst.create_get_site_info_response('TEST:SITE_A')
+        response_string = self.response_to_StringIO(response,
+                                                    'sitesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_siteinfo_novar_1_1.xml')
+
+    def test_get_site_info_withvar(self):
+        response = self.wof_inst.create_get_site_info_response(
+            'TEST:SITE_B',
+            'TESTVocab:TP')
+        response_string = self.response_to_StringIO(response,
+                                                    'sitesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_siteinfo_withvar_1_1.xml')
+
+    def test_get_values_encloses_por(self):
+        response = self.wof_inst.create_get_values_response(
+            'TEST:SITE_A',
+            'TESTVocab:Temp',
+            startDateTime='2007-03-05 00:00',
+            endDateTime='2007-05-06 00:00')
+        response_string = self.response_to_StringIO(response,
+                                                    'timeSeriesResponse')
+
+        assert response_string != None
+        # self.compare_output_to_known_xml(response_string,
+        #                                  'get_values_encloses_por_1_1.xml')
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestWOF))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/wof/WaterML_1_1.py
+++ b/wof/WaterML_1_1.py
@@ -402,7 +402,7 @@ def quote_xml(inStr):
         pos = mo.end()
     s3 = s1[pos:]
     s2 += quote_xml_aux(s3)
-    return s2
+    return s2.decode(ExternalEncoding)
 
 
 def quote_xml_aux(inStr):


### PR DESCRIPTION
This PR test for encoding/decoding issues. Though it is currently only for WaterML 1.1. Which is why I duplicated `test_dao.py` into `test_dao_1_1.py`. If I don't do this, the other test `test_wof.py` will fail since I haven't implement fix for unicode/decoding handling for WaterML 1.0.