### PR TITLE
Add GetVariables to default HTML WOFpy REST 1.1 endpoint page

### DIFF
--- a/wof/flask/templates/index_1_1.html
+++ b/wof/flask/templates/index_1_1.html
@@ -31,6 +31,11 @@
                         GetSiteInfoMultple?site={{p}}:{{s}}
                     </a>
                 </li>
+        <li>
+                    <a href="{{request.script_root|safe}}/{{ path }}GetVariables">
+                        GetVariables
+                    </a>
+                </li>
 		<li>
                     <a href="{{request.script_root|safe}}/{{ path }}GetVariableInfo">
                         GetVariableInfo


### PR DESCRIPTION
## Overview 

This PR adds `GetVariables` in `../rest_1_1/` WOFpy REST sample page.

Adressing @emiliom comment: https://github.com/ODM2/WOFpy/issues/165#issuecomment-323417817

## Demo
![screenshot from 2017-08-18 11-05-02](https://user-images.githubusercontent.com/17802172/29471563-5186138e-8405-11e7-9160-59e0ca0c88d1.png)
