### PR TITLE
Fix logic for siteProperty

### DIFF
--- a/wof/core_1_1.py
+++ b/wof/core_1_1.py
@@ -674,13 +674,7 @@ class WOF_1_1(object):
 
         site.set_siteInfo(siteInfo)
 
-        # Need at least one note element to meet WaterML 1.0 schema validation,
-        if (not siteResult.County and not
-           siteResult.State and not
-           siteResult.Comments):
-
-            siteInfo.add_note(WaterML.PropertyType())
-        else:
+        if any([siteResult.County, siteResult.State, siteResult.Comments]):
             if siteResult.County:
                 countyNote = WaterML.PropertyType(
                     name="County",


### PR DESCRIPTION
## Overview
This PR addresses #168. Now `siteProperty` is shown only when there is value in it. Also, `note` has been removed since it's deprecated from WaterML 1.1.

## Notes
I have tested the response locally with ulmo for SOAP and REST request, and now Postgresql works, because the response is able to be parsed.