### PR TITLE
Add cvmapping from ODM2 to WaterML1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
   - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install WOFpy-${version}.tar.gz && popd
 
 before_script:
-  - python wof/examples/flask/cbi/build_cbi_cache.py
+# Commented out due to external service not working. 8/30/17. lsetiawan.
+#  - python wof/examples/flask/cbi/build_cbi_cache.py
   - python wof/examples/flask/swis/runserver_swis.py --config=./test/test_swis_config2.cfg --connection=sqlite:///./test/test_swis2.db &
 
 script:

--- a/wof/examples/flask/odm2/cvmap_wml_1_1.yml
+++ b/wof/examples/flask/odm2/cvmap_wml_1_1.yml
@@ -1,0 +1,41 @@
+censorcode:
+  gt:
+  - Greater than
+  lt:
+  - Less than
+  nc:
+  - Not censored
+  nd:
+  - Non-detect
+  pnq:
+  - Present but not quantified
+
+
+datatype:
+  Best Easy Systematic Estimator:
+  - Best easy systematic estimator
+  Constant Over Interval:
+  - Constant over interval
+  StandardDeviation:
+  - Standard deviation
+
+samplemedium:
+  Not Relevant:
+  - Not applicable
+  Other:
+  - Rock
+  - Regolith
+  - Mineral
+  - Ice
+  - Habitat
+  Surface water:
+  - Liquid aqueous
+  - Liquid organic
+  Suspended particulate matter:
+  - Particulate
+  Tissue:
+  - Organism
+  Tree:
+  - Vegetation
+  Wellhead Gas:
+  - Gas

--- a/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
+++ b/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
@@ -3,6 +3,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 from dateutil.parser import parse
+import os
+import yaml
 
 from sqlalchemy import (create_engine, func)
 from sqlalchemy.orm import (scoped_session, sessionmaker)
@@ -11,7 +13,6 @@ from odm2api.ODM2 import models as odm2_models
 
 import wof.examples.flask.odm2.timeseries.sqlalch_odm2_models as model
 from wof.dao import BaseDao
-import yaml
 
 
 class Odm2Dao(BaseDao):
@@ -39,7 +40,7 @@ class Odm2Dao(BaseDao):
         self.db_session = Session()
 
         # Read in WaterML -> ODM2 CV Mapping
-        with open('../cvmap_wml_1_1.yml') as yml:
+        with open(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'cvmap_wml_1_1.yml'))) as yml:
             self.yml_dict = yaml.load(yml)
 
     def __del__(self):

--- a/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
+++ b/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
@@ -11,6 +11,7 @@ from odm2api.ODM2 import models as odm2_models
 
 import wof.examples.flask.odm2.timeseries.sqlalch_odm2_models as model
 from wof.dao import BaseDao
+import yaml
 
 
 class Odm2Dao(BaseDao):
@@ -37,6 +38,10 @@ class Odm2Dao(BaseDao):
 
         self.db_session = Session()
 
+        # Read in WaterML -> ODM2 CV Mapping
+        with open('../cvmap_wml_1_1.yml') as yml:
+            self.yml_dict = yaml.load(yml)
+
     def __del__(self):
         """Closes Database Session."""
         self.db_session.close()
@@ -48,6 +53,12 @@ class Odm2Dao(BaseDao):
             self.db_session.rollback()
         finally:
             pass
+
+    def get_match(self, cvkey, term):
+        for k, v in self.yml_dict[cvkey].items():
+            if term in v:
+                return k
+        return term
 
     def get_all_sites(self):
         """Get all wof sites from odm2 database.
@@ -190,6 +201,9 @@ class Odm2Dao(BaseDao):
                     ti = result.TimeAggregationInterval
                     ag = result.ResultObj.AggregationStatisticCV
                     w_v = model.Variable(v, s, u, t, ti, ag)
+                    w_v.DataType = self.get_match('datatype', w_v.DataType)
+                    w_v.SampleMedium = self.get_match('samplemedium', w_v.SampleMedium)
+
                     v_arr.append(w_v)
 
         return v_arr
@@ -258,6 +272,7 @@ class Odm2Dao(BaseDao):
             r[i].tsrv_EndDateTime = edt_dict[r[i].ResultID]
 
             w_r = model.Series(r[i], aff)
+            w_r.SampleMedium = self.get_match('samplemedium', w_r.SampleMedium)
             r_arr.append(w_r)
         return r_arr
 
@@ -297,6 +312,7 @@ class Odm2Dao(BaseDao):
             r[i].tsrv_EndDateTime = edt_dict[r[i].ResultID]
 
             w_r = model.Series(r[i], aff)
+            w_r.SampleMedium = self.get_match('samplemedium', w_r.SampleMedium)
             r_arr.append(w_r)
         return r_arr
 
@@ -359,6 +375,7 @@ class Odm2Dao(BaseDao):
                         join(odm2_models.ActionBy). \
                         filter(odm2_models.ActionBy.ActionID == act_id).first()
                 w_v = model.DataValue(valueResult, aff)
+                w_v.CensorCode = self.get_match('censorcode', w_v.CensorCode)
                 v_arr.append(w_v)
         return v_arr
 


### PR DESCRIPTION
## Overview

This PR addresses #160. This adds CV mapping for `CensorCode`, `DataType`, and `SampleMedium`. Other mappings are still in progress. This method will only address the ODM2 vocabularies that are short. 
## Demo

### Before
```xml
<variable>
<variableCode default="true" vocabulary="mysqlodm2timeseries" variableID="4">USU4</variableCode>
<variableName>Turbidity</variableName>
<valueType>Unknown</valueType>
<dataType>Unknown</dataType>
<generalCategory>Unknown</generalCategory>
<sampleMedium>Unknown</sampleMedium>
...
```

### After
```xml
<variable>
<variableCode default="true" vocabulary="mysqlodm2timeseries" variableID="4">USU4</variableCode>
<variableName>Turbidity</variableName>
<valueType>Unknown</valueType>
<dataType>Average</dataType>
<generalCategory>Water Quality</generalCategory>
<sampleMedium>Surface water</sampleMedium>
...
```


## Notes

This functionality has been tested on the wofpy development server on AWS. Now the correct Vocabularies are showing up. See demo above.

