### PR TITLE
Fixed Series/Site CV assignments for ODM2 timeseries DAO

### DIFF
--- a/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
+++ b/wof/examples/flask/odm2/timeseries/odm2_timeseries_dao.py
@@ -156,8 +156,7 @@ class Odm2Dao(BaseDao):
         l_var_codes = None
         if var_codes is not None:
             if not isinstance(var_codes, list):
-                l_var_codes = []
-                l_var_codes.append(var_codes)
+                l_var_codes = [var_codes]
             else:
                 l_var_codes = var_codes
 
@@ -205,7 +204,6 @@ class Odm2Dao(BaseDao):
                     w_v = model.Variable(v, s, u, t, ti, ag, at)
                     w_v.DataType = self.get_match('datatype', w_v.DataType)
                     w_v.SampleMedium = self.get_match('samplemedium', w_v.SampleMedium)
-
                     v_arr.append(w_v)
 
         return v_arr
@@ -274,7 +272,9 @@ class Odm2Dao(BaseDao):
             r[i].tsrv_EndDateTime = edt_dict[r[i].ResultID]
 
             w_r = model.Series(r[i], aff)
-            w_r.SampleMedium = self.get_match('samplemedium', w_r.SampleMedium)
+            w_r.Variable.DataType = self.get_match('datatype', w_r.Variable.DataType)
+            w_r.Variable.SampleMedium = self.get_match('samplemedium', w_r.Variable.SampleMedium)
+            w_r.SampleMedium = w_r.Variable.SampleMedium
             r_arr.append(w_r)
         return r_arr
 
@@ -314,7 +314,9 @@ class Odm2Dao(BaseDao):
             r[i].tsrv_EndDateTime = edt_dict[r[i].ResultID]
 
             w_r = model.Series(r[i], aff)
-            w_r.SampleMedium = self.get_match('samplemedium', w_r.SampleMedium)
+            w_r.Variable.DataType = self.get_match('datatype', w_r.Variable.DataType)
+            w_r.Variable.SampleMedium = self.get_match('samplemedium', w_r.Variable.SampleMedium)
+            w_r.SampleMedium = w_r.Variable.SampleMedium
             r_arr.append(w_r)
         return r_arr
 

--- a/wof/examples/flask/odm2/timeseries/sqlalch_odm2_models.py
+++ b/wof/examples/flask/odm2/timeseries/sqlalch_odm2_models.py
@@ -27,11 +27,12 @@ class Variable(wof_base.BaseVariable):
         self.VariableName = v.VariableNameCV
         self.VariableDescription = v.VariableDefinition
         self.NoDataValue = v.NoDataValue
-        self.SampleMedium = VarSampleMedium
-        self.DataType = aggregationstatisticCV
         self.Speciation = v.SpeciationCV
         self.VariableUnitsID = v_unit.UnitsID
         self.GeneralCategory = v.VariableTypeCV
+
+        self.SampleMedium = VarSampleMedium
+        self.DataType = aggregationstatisticCV
         self.ValueType = actiontypeCV
 
         self.GeneralCategoryValidate = False
@@ -108,7 +109,8 @@ class Series(wof_base.BaseSeries):
         # self.SiteCode = sf_obj.SamplingFeatureCode
         # self.SiteName = sf_obj.SamplingFeatureName
 
-        self.Variable = Variable(v_obj, r.SampledMediumCV, u_obj)
+        self.Variable = Variable(v=v_obj, VarSampleMedium=r.SampledMediumCV, v_unit=u_obj,
+                                 aggregationstatisticCV=r.AggregationStatisticCV, actiontypeCV=a_obj.ActionTypeCV)
         # self.VariableID = r.VariableID
         # self.VariableCode = v_obj.VariableCode
         # self.VariableName = v_obj.VariableNameCV


### PR DESCRIPTION
Addresses CV handling problem described in https://github.com/ODM2/WOFpy/issues/160#issuecomment-326148477, where not all CV's in `GetSite*` responses were still not being populated, for the ODM2 timeseries DAO. Specifically, this:

- `GetSiteInfo` responses have "Unknown" values for `valueType`, `dataType` and `sampleMedium`, in both databases/endpoints.

Untested! @lsetiawan, please test it first.