### PR TITLE
Updated setup.py metadata and samplemedium ODM2-WaterML1.1 CV mapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ setup(
     author_email='james.seppi@gmail.com',
     # note: maintainer gets listed as author in PKG-INFO, so leaving
     # this commented out for now
-    maintainer='David Valentine',
-    maintainer_email='david.valentine@gmail.com',
+    maintainer='Emilio Mayorga',
+    maintainer_email='emiliom@uw.edu',
     description='a python library for serving WaterOneFlow web services',
     long_description=__doc__,
-    keywords='cuahsi his wofpy water waterml cuahsi wateroneflow odm2 czodata',
+    keywords='cuahsi his wofpy water waterml cuahsi wateroneflow odm2',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
@@ -57,7 +57,7 @@ setup(
     },
     tests_require=['suds-jurko', 'requests'],
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/wof/examples/flask/odm2/cvmap_wml_1_1.yml
+++ b/wof/examples/flask/odm2/cvmap_wml_1_1.yml
@@ -19,23 +19,22 @@ datatype:
   StandardDeviation:
   - Standard deviation
 
+
 samplemedium:
   Not Relevant:
   - Not applicable
   Other:
+  - Vegetation
   - Rock
   - Regolith
+  - Organism
   - Mineral
+  - Liquid organic
   - Ice
   - Habitat
+  - Gas
+  - Equipment
   Surface water:
   - Liquid aqueous
-  - Liquid organic
   Suspended particulate matter:
   - Particulate
-  Tissue:
-  - Organism
-  Tree:
-  - Vegetation
-  Wellhead Gas:
-  - Gas


### PR DESCRIPTION
Final changes before issuing the new release.

- Updated setup.py metadata (maintainer, keywords, and classifiers > Development Status)
- Refined (finalized) ODM2 DAO vocabulary mappings to `samplemedium` WaterML 1.1 CVs (in `cvmap_wml_1_1.yml` yaml file)
