### PR TITLE
Update SOAPandREST Tests ipynb

### DIFF
--- a/docs/WOFpy_ODM2_SOAPandREST_Tests.ipynb
+++ b/docs/WOFpy_ODM2_SOAPandREST_Tests.ipynb
@@ -16,10 +16,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/lsetiawan/miniconda/envs/wofpy/lib/python2.7/site-packages/ulmo/twc/kbdi/core.py:20: FutureWarning: pandas.tslib is deprecated and will be removed in a future version.\n",
+      "You can access Timestamp as pandas.Timestamp\n",
+      "  CSV_SWITCHOVER = pandas.tslib.Timestamp('2016-10-01')\n"
+     ]
+    }
+   ],
    "source": [
     "from urlparse import urljoin\n",
     "import io\n",
@@ -32,9 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -58,9 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -138,7 +142,6 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -150,40 +153,10 @@
       "Testing http://54.186.36.247:8080/postgresqlodm2timeseries/soap/cuahsi_1_1/.wsdl\n",
       "--------------------------\n",
       "SITES-----------------\n",
-      "GetSites failed!\n",
-      "*** KeyError:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"<ipython-input-7-53857f5fcb02>\", line 12, in <module>\n",
-      "    sites = ulmo.cuahsi.wof.get_sites(url)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/cuahsi/wof/core.py\", line 60, in get_sites\n",
-      "    sites = waterml.v1_1.parse_site_infos(response_buffer)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/v1_1.py\", line 9, in parse_site_infos\n",
-      "    content_io, WATERML_V1_1_NAMESPACE, site_info_names=['siteInfo', 'sourceInfo'])\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 108, in parse_site_infos\n",
-      "    for site_info_element in site_info_elements\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 324, in _parse_site_info\n",
-      "    for note in site_info.findall(namespace + 'note')\n",
-      "  File \"src/lxml/lxml.etree.pyx\", line 2452, in lxml.etree._Attrib.__getitem__ (src/lxml/lxml.etree.c:68625)\n",
-      "KeyError: 'title'\n",
+      "['postgresqlodm2timeseries:LaSalleN', 'postgresqlodm2timeseries:NHPK8S', 'postgresqlodm2timeseries:160065_CrosslandsPond', 'postgresqlodm2timeseries:LaSalleE', 'postgresqlodm2timeseries:USU-LBR-Mendon', 'postgresqlodm2timeseries:srgd_mass_test', 'postgresqlodm2timeseries:PKCV3S', 'postgresqlodm2timeseries:USU-UWRL', 'postgresqlodm2timeseries:GermantownFS', 'postgresqlodm2timeseries:Ben_Desk', 'postgresqlodm2timeseries:JHDR', \"postgresqlodm2timeseries:Craig's_Desk_Test\", 'postgresqlodm2timeseries:abcdabcd', 'postgresqlodm2timeseries:desk_sensors', 'postgresqlodm2timeseries:JRains1', 'postgresqlodm2timeseries:JRains2', 'postgresqlodm2timeseries:srgd_desk', 'postgresqlodm2timeseries:TKessler2', 'postgresqlodm2timeseries:RockyLow', 'postgresqlodm2timeseries:sdfasd', 'postgresqlodm2timeseries:RockeyUp', 'postgresqlodm2timeseries:HOME', 'postgresqlodm2timeseries:Test', 'postgresqlodm2timeseries:NHMU9S', 'postgresqlodm2timeseries:EDIT_SITE', 'postgresqlodm2timeseries:Nicks_Desk', 'postgresqlodm2timeseries:srgd_home', 'postgresqlodm2timeseries:PKCV2S', 'postgresqlodm2timeseries:ZYU1', 'postgresqlodm2timeseries:BeaverLow', 'postgresqlodm2timeseries:ASITE', 'postgresqlodm2timeseries:Casia', 'postgresqlodm2timeseries:NHPK7S', 'postgresqlodm2timeseries:TESTzzz', 'postgresqlodm2timeseries:Hurricane', 'postgresqlodm2timeseries:SDH_test1', 'postgresqlodm2timeseries:RockyUp', 'postgresqlodm2timeseries:160065_4vars', 'postgresqlodm2timeseries:NHMU10S', 'postgresqlodm2timeseries:Anthonys_Desk', 'postgresqlodm2timeseries:Ramsey', 'postgresqlodm2timeseries:160065_Crosslands']\n",
       "\n",
       "SITE INFO postgresqlodm2timeseries:160065_4vars-------------\n",
-      "GetSiteInfo failed!\n",
-      "*** KeyError:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"<ipython-input-7-53857f5fcb02>\", line 23, in <module>\n",
-      "    siteinfo = ulmo.cuahsi.wof.get_site_info(url, site_code=sitecode)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/cuahsi/wof/core.py\", line 105, in get_site_info\n",
-      "    sites = waterml.v1_1.parse_sites(response_buffer)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/v1_1.py\", line 21, in parse_sites\n",
-      "    return common.parse_sites(content_io, WATERML_V1_1_NAMESPACE)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 124, in parse_sites\n",
-      "    for site_element in site_elements]\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 281, in _parse_site\n",
-      "    site_dict = _parse_site_info(site.find(namespace + 'siteInfo'), namespace)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 324, in _parse_site_info\n",
-      "    for note in site_info.findall(namespace + 'note')\n",
-      "  File \"src/lxml/lxml.etree.pyx\", line 2452, in lxml.etree._Attrib.__getitem__ (src/lxml/lxml.etree.c:68625)\n",
-      "KeyError: 'title'\n",
+      "160065 Crosslands Pond with 4 variables\n",
       "\n",
       "VARIABLES-------------\n",
       "['postgresqlodm2timeseries:EnviroDIY_Mayfly_Volt', 'postgresqlodm2timeseries:Adafruit_DS18B20_Temp', 'postgresqlodm2timeseries:Decagon_ES-2_EC', 'postgresqlodm2timeseries:Adafruit_AM2315_humidity', 'postgresqlodm2timeseries:Decagon_CTD-10_Depth', 'postgresqlodm2timeseries:Decagon_5TM_VWC', 'postgresqlodm2timeseries:Adafruit_AM2315_Temp', 'postgresqlodm2timeseries:Campbell_OBS-3+_Turb', 'postgresqlodm2timeseries:EnviroDIY_Mayfly_FreeSRAM', 'postgresqlodm2timeseries:EnviroDIY_Mayfly_Temp', 'postgresqlodm2timeseries:Decagon_5TM_Ea', 'postgresqlodm2timeseries:Decagon_CTD-10_Temp', 'postgresqlodm2timeseries:Decagon_CTD-10_EC', 'postgresqlodm2timeseries:Seeed_BME280_Temp', 'postgresqlodm2timeseries:Seeed_BME280_humidity', 'postgresqlodm2timeseries:Decagon_ES-2_Temp', 'postgresqlodm2timeseries:Decagon_5TM_Temp', 'postgresqlodm2timeseries:MaxBotix_MB7386_Distance']\n",
@@ -201,7 +174,7 @@
       "['mysqlodm2timeseries:USU-LBR-Mendon', 'mysqlodm2timeseries:USU-LBR-SFWeather']\n",
       "\n",
       "SITE INFO mysqlodm2timeseries:USU-LBR-Mendon-------------\n",
-      "{'site_comments': 'Located below county road bridge at Mendon Road crossing'}\n",
+      "Little Bear River at Mendon Road near Mendon, Utah\n",
       "\n",
       "VARIABLES-------------\n",
       "['mysqlodm2timeseries:USU57', 'mysqlodm2timeseries:USU56', 'mysqlodm2timeseries:USU55', 'mysqlodm2timeseries:USU54', 'mysqlodm2timeseries:USU53', 'mysqlodm2timeseries:USU52', 'mysqlodm2timeseries:USU51', 'mysqlodm2timeseries:USU47', 'mysqlodm2timeseries:USU59', 'mysqlodm2timeseries:USU58', 'mysqlodm2timeseries:USU13', 'mysqlodm2timeseries:USU10', 'mysqlodm2timeseries:USU17', 'mysqlodm2timeseries:USU16', 'mysqlodm2timeseries:USU15', 'mysqlodm2timeseries:USU14', 'mysqlodm2timeseries:USU35', 'mysqlodm2timeseries:USU34', 'mysqlodm2timeseries:USU37', 'mysqlodm2timeseries:USU36', 'mysqlodm2timeseries:USU31', 'mysqlodm2timeseries:USU30', 'mysqlodm2timeseries:USU33', 'mysqlodm2timeseries:USU32', 'mysqlodm2timeseries:USU7', 'mysqlodm2timeseries:USU6', 'mysqlodm2timeseries:USU5', 'mysqlodm2timeseries:USU4', 'mysqlodm2timeseries:USU3', 'mysqlodm2timeseries:USU9', 'mysqlodm2timeseries:USU8', 'mysqlodm2timeseries:USU19', 'mysqlodm2timeseries:USU62', 'mysqlodm2timeseries:USU60', 'mysqlodm2timeseries:USU61', 'mysqlodm2timeseries:USU18', 'mysqlodm2timeseries:USU44', 'mysqlodm2timeseries:USU50', 'mysqlodm2timeseries:USU48', 'mysqlodm2timeseries:USU49', 'mysqlodm2timeseries:USU28', 'mysqlodm2timeseries:USU29', 'mysqlodm2timeseries:USU26', 'mysqlodm2timeseries:USU27', 'mysqlodm2timeseries:USU24', 'mysqlodm2timeseries:USU25', 'mysqlodm2timeseries:USU22', 'mysqlodm2timeseries:USU23', 'mysqlodm2timeseries:USU20', 'mysqlodm2timeseries:USU21']\n",
@@ -240,7 +213,7 @@
     "    try:\n",
     "        siteinfo = ulmo.cuahsi.wof.get_site_info(url, site_code=sitecode)\n",
     "        \n",
-    "        print(siteinfo['site_property'])\n",
+    "        print(siteinfo['name'])\n",
     "        print('')\n",
     "    except:\n",
     "        print('GetSiteInfo failed!')\n",
@@ -288,9 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -300,36 +271,10 @@
       "Testing http://54.186.36.247:8080/postgresqlodm2timeseries/rest/1_1/\n",
       "--------------------------\n",
       "SITES-----------------\n",
-      "GetSites failed!\n",
-      "*** KeyError:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"<ipython-input-8-580ac2f81f0e>\", line 14, in <module>\n",
-      "    sites = ulmo.waterml.v1_1.parse_site_infos(response_buffer)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/v1_1.py\", line 9, in parse_site_infos\n",
-      "    content_io, WATERML_V1_1_NAMESPACE, site_info_names=['siteInfo', 'sourceInfo'])\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 108, in parse_site_infos\n",
-      "    for site_info_element in site_info_elements\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 324, in _parse_site_info\n",
-      "    for note in site_info.findall(namespace + 'note')\n",
-      "  File \"src/lxml/lxml.etree.pyx\", line 2452, in lxml.etree._Attrib.__getitem__ (src/lxml/lxml.etree.c:68625)\n",
-      "KeyError: 'title'\n",
+      "['PKCV2S', 'ZYU1', 'SDH_test1', 'RockyUp', 'BeaverLow', 'Hurricane', 'TESTzzz', 'RockeyUp', 'NHMU10S', 'Anthonys_Desk', 'Test', 'HOME', 'NHMU9S', '160065_4vars', 'EDIT_SITE', 'sdfasd', 'NHPK7S', 'Ramsey', 'Casia', 'ASITE', 'JRains2', 'JRains1', 'JHDR', 'abcdabcd', 'desk_sensors', 'PKCV3S', '160065_CrosslandsPond', 'TKessler2', 'NHPK8S', 'RockyLow', 'USU-LBR-Mendon', 'LaSalleE', \"Craig's_Desk_Test\", 'srgd_mass_test', 'LaSalleN', '160065_Crosslands', 'srgd_home', 'USU-UWRL', 'GermantownFS', 'Ben_Desk', 'Nicks_Desk', 'srgd_desk']\n",
       "\n",
       "SITE INFO postgresqlodm2timeseries:160065_4vars-------------\n",
-      "GetSiteInfo failed!\n",
-      "*** KeyError:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"<ipython-input-8-580ac2f81f0e>\", line 26, in <module>\n",
-      "    siteinfo = ulmo.waterml.v1_1.parse_sites(response_buffer)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/v1_1.py\", line 21, in parse_sites\n",
-      "    return common.parse_sites(content_io, WATERML_V1_1_NAMESPACE)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 124, in parse_sites\n",
-      "    for site_element in site_elements]\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 281, in _parse_site\n",
-      "    site_dict = _parse_site_info(site.find(namespace + 'siteInfo'), namespace)\n",
-      "  File \"//anaconda/envs/uwapl_em_mc_1aui/lib/python2.7/site-packages/ulmo/waterml/common.py\", line 324, in _parse_site_info\n",
-      "    for note in site_info.findall(namespace + 'note')\n",
-      "  File \"src/lxml/lxml.etree.pyx\", line 2452, in lxml.etree._Attrib.__getitem__ (src/lxml/lxml.etree.c:68625)\n",
-      "KeyError: 'title'\n",
+      "160065 Crosslands Pond with 4 variables\n",
       "\n",
       "VARIABLES-------------\n",
       "['Decagon_CTD-10_Temp', 'Decagon_5TM_Temp', 'EnviroDIY_Mayfly_Temp', 'Adafruit_AM2315_Temp', 'EnviroDIY_Mayfly_Volt', 'Decagon_CTD-10_EC', 'Decagon_5TM_Ea', 'Seeed_BME280_Temp', 'Campbell_OBS-3+_Turb', 'Decagon_ES-2_EC', 'Decagon_CTD-10_Depth', 'Decagon_5TM_VWC', 'Decagon_ES-2_Temp', 'MaxBotix_MB7386_Distance', 'Adafruit_AM2315_humidity', 'EnviroDIY_Mayfly_FreeSRAM', 'Seeed_BME280_humidity', 'Adafruit_DS18B20_Temp']\n",
@@ -347,7 +292,7 @@
       "['USU-LBR-Mendon', 'USU-LBR-SFWeather']\n",
       "\n",
       "SITE INFO mysqlodm2timeseries:USU-LBR-Mendon-------------\n",
-      "{'site_comments': 'Located below county road bridge at Mendon Road crossing'}\n",
+      "Little Bear River at Mendon Road near Mendon, Utah\n",
       "\n",
       "VARIABLES-------------\n",
       "['USU36', 'USU35', 'USU44', 'USU47', 'USU48', 'USU49', 'USU30', 'USU26', 'USU27', 'USU24', 'USU25', 'USU22', 'USU23', 'USU20', 'USU21', 'USU62', 'USU31', 'USU60', 'USU61', 'USU28', 'USU29', 'USU7', 'USU6', 'USU5', 'USU4', 'USU3', 'USU33', 'USU32', 'USU9', 'USU8', 'USU57', 'USU56', 'USU55', 'USU54', 'USU53', 'USU52', 'USU51', 'USU50', 'USU59', 'USU58', 'USU13', 'USU34', 'USU37', 'USU10', 'USU17', 'USU16', 'USU15', 'USU14', 'USU19', 'USU18']\n",
@@ -389,7 +334,7 @@
     "        response_buffer = io.BytesIO(ulmo.util.to_bytes(req.content))\n",
     "        siteinfo = ulmo.waterml.v1_1.parse_sites(response_buffer)\n",
     "        \n",
-    "        print(siteinfo[sitecode.split(':')[1]]['site_property'])\n",
+    "        print(siteinfo[sitecode.split(':')[1]]['name'])\n",
     "        print('')\n",
     "    except:\n",
     "        print('GetSiteInfo failed!')\n",
@@ -460,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Overview

This PR addresses https://github.com/ODM2/WOFpy/issues/166#issuecomment-326414279. The Jupyter Notebook that runs some test requests to the "live" WOFpy instance on the clouds has been updated to test the latest release. The instance has also been updated to version 2.2.0.