### PR TITLE
Add an option to connection_String of .cfg file

### DIFF
--- a/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
+++ b/wof/examples/flask/odm2/timeseries/odm2_config_timeseries.cfg
@@ -26,4 +26,4 @@ Templates: ../../../../../wof/flask/templates
 
 [Database]
 # The name of a file containing the Connection String eg: private.connection which has: mysql://username:password@localhost/database
-Connection_String: sqlite:///../../../../../test/odm2/ODM2.sqlite
+Connection_String: sqlite:///../../../../../test/odm2/ODM2.sqlite?check_same_thread=False


### PR DESCRIPTION
I got some troubles about multi-thread of SQLite sometimes when I run the the example with the configuration file.
Even WOFpy web service was not working well when I wanted to get values of specific time period.
The error(e.g. Not Found error) was not occurred anymore after adding 'check_same_thread=False' part at the last line.