### PR TITLE
use conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
   - conda config --set show_channel_urls true
-  - conda config --add channels odm2 --force
+  - conda config --add channels conda-forge --force
   - conda create -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -76,7 +76,6 @@ script:
     fi
 
   - if [[ $TEST_TARGET == 'coding_standards' ]]; then
-      conda install --channel conda-forge flake8 flake8-print flake8-quotes flake8-import-order flake8-builtins flake8-comprehensions flake8-mutable
       flake8 --max-line-length=105 wof ;
       flake8 --max-line-length=105 test ;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
     - cmd: conda update conda
-    - cmd: conda config --add channels odm2 --force
+    - cmd: conda config --add channels conda-forge --force
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,12 @@ uwsgi
 geoalchemy-odm2
 # testing
 pytest
+# coding standards
 pycodestyle
+flake8
+flake8-print
+flake8-quotes
+flake8-import-order
+flake8-builtins
+flake8-comprehensions
+flake8-mutable


### PR DESCRIPTION
@lsetiawan and @emiliom this PR makes use of the conda-forge version of the `odm2` packages. If things are working as expected we can re-add the `flak8-*` in the `requirements-dev.txt ` b/c, without a 3rd channel, we reduce the channel incompatibilities.